### PR TITLE
Fix on ROCm 5.3.0 builds

### DIFF
--- a/platforms/hip/src/HipContext.cpp
+++ b/platforms/hip/src/HipContext.cpp
@@ -191,8 +191,6 @@ HipContext::HipContext(const System& system, int deviceIndex, bool useBlockingSy
 
     contextIsValid = true;
     ContextSelector selector(*this);
-    // note: this is a no-op on AMD GPUs
-    CHECK_RESULT(hipDeviceSetCacheConfig(hipFuncCachePreferShared));
     if (contextIndex > 0) {
         int canAccess;
         CHECK_RESULT(hipDeviceCanAccessPeer(&canAccess, getDevice(), platformData.contexts[0]->getDevice()));


### PR DESCRIPTION
Removing this function call gets rid of the error we're seeing when trying to upgrade OpenMM to ROCm 5.3.0. It is a no-op to begin with, so no biggie.