### PR TITLE
Add ATMForce

### DIFF
--- a/platforms/hip/include/HipKernels.h
+++ b/platforms/hip/include/HipKernels.h
@@ -360,6 +360,18 @@ public:
     }
 };
 
+/**
+ * This kernel is invoked by ATMForce to calculate the forces acting on the system and the energy of the system.
+ */
+class HipCalcATMForceKernel : public CommonCalcATMForceKernel {
+public:
+    HipCalcATMForceKernel(std::string name, const Platform& platform, ComputeContext& cc) : CommonCalcATMForceKernel(name, platform, cc) {
+    }
+    ComputeContext& getInnerComputeContext(ContextImpl& innerContext) {
+        return *reinterpret_cast<HipPlatform::PlatformData*>(innerContext.getPlatformData())->contexts[0];
+    }
+};
+
 } // namespace OpenMM
 
 #endif /*OPENMM_HIPKERNELS_H_*/

--- a/platforms/hip/src/HipKernelFactory.cpp
+++ b/platforms/hip/src/HipKernelFactory.cpp
@@ -141,5 +141,7 @@ KernelImpl* HipKernelFactory::createKernelImpl(std::string name, const Platform&
         return new CommonApplyMonteCarloBarostatKernel(name, platform, cu);
     if (name == RemoveCMMotionKernel::Name())
         return new CommonRemoveCMMotionKernel(name, platform, cu);
+    if (name == CalcATMForceKernel::Name() )
+        return new HipCalcATMForceKernel(name, platform, cu);
     throw OpenMMException((std::string("Tried to create kernel with illegal kernel name '")+name+"'").c_str());
 }

--- a/platforms/hip/src/HipPlatform.cpp
+++ b/platforms/hip/src/HipPlatform.cpp
@@ -108,6 +108,7 @@ HipPlatform::HipPlatform() {
     registerKernelFactory(ApplyAndersenThermostatKernel::Name(), factory);
     registerKernelFactory(ApplyMonteCarloBarostatKernel::Name(), factory);
     registerKernelFactory(RemoveCMMotionKernel::Name(), factory);
+    registerKernelFactory(CalcATMForceKernel::Name(), factory);
     platformProperties.push_back(HipDeviceIndex());
     platformProperties.push_back(HipDeviceName());
     platformProperties.push_back(HipUseBlockingSync());


### PR DESCRIPTION
This ports the Alchemical Transfer Method potential ([ATMForce](https://github.com/openmm/openmm/pull/4110)) recently integrated into OpenMM's main branch to the HIP platform.

The [AToM-OpenMM](https://github.com/Gallicchio-Lab/AToM-OpenMM) protein-ligand binding free energy application is based on ATMForce. It runs well on AMD hardware.