### PR TITLE
Fix incomplete PTX file written to disk

### DIFF
--- a/platforms/hip/src/HipContext.cpp
+++ b/platforms/hip/src/HipContext.cpp
@@ -607,7 +607,7 @@ hipModule_t HipContext::createModule(const string source, const map<string, stri
 
         bool wroteCache = false;
         try {
-            ofstream out(outputFile.c_str());
+            ofstream out(outputFile.c_str(), ios::out | ios::binary);
             out.write(&ptx[0], ptx.size());
             out.close();
             if (!out.fail())


### PR DESCRIPTION
Bytes written is sometimes less than original ptx.size() and hipModuleLoad throws an a string too long exception. Setting binary output writes all the bytes.